### PR TITLE
Fix organization and group pages: List datasets

### DIFF
--- a/components/_shared/DatasetList.tsx
+++ b/components/_shared/DatasetList.tsx
@@ -18,7 +18,7 @@ export default function DatasetList({ type, name, initialDatasets }: DatasetList
   const limit = 10;
 
   const fq = type === "organization" 
-    ? `(organization:${name})` 
+    ? `(owner_org:${name})` 
     : `(groups:${name})`;
 
   const { data: searchResults, isValidating } = useSWR(

--- a/pages/[org]/index.tsx
+++ b/pages/[org]/index.tsx
@@ -36,7 +36,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   if (org.package_count) {
     initialDatasets = await searchDatasets({
-      fq: `organization:${org._name}`,
+      fq: `owner_org:${org.id}`,
       offset: 0,
       limit: 10,
       type: "dataset",
@@ -69,7 +69,7 @@ export default function OrgPage({ org, initialDatasets }): JSX.Element {
     {
       id: "datasets",
       content: (
-        <DatasetList type="organization" name={org._name} initialDatasets={initialDatasets} />
+        <DatasetList type="organization" name={org.id} initialDatasets={initialDatasets} />
       ),
       title: "Datasets",
     },

--- a/pages/groups/[groupName].tsx
+++ b/pages/groups/[groupName].tsx
@@ -29,7 +29,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   let initialDatasets = null;
   if (group.package_count) {
     initialDatasets = await searchDatasets({
-      fq: `groups:${group.id}`,
+      fq: `groups:${group.name}`,
       offset: 0,
       limit: 10,
       type: "dataset",
@@ -61,6 +61,7 @@ export default function GroupPage({ group, initialDatasets }): JSX.Element {
     {
       id: "datasets",
       content:  (
+        //TO DO: index search by group name
         <DatasetList type="group" name={group?.groups[0]?.name+'--'+group.name} initialDatasets={initialDatasets} />
       ),
       title: "Datasets",

--- a/pages/groups/[groupName].tsx
+++ b/pages/groups/[groupName].tsx
@@ -29,7 +29,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   let initialDatasets = null;
   if (group.package_count) {
     initialDatasets = await searchDatasets({
-      fq: `groups:${group._name}`,
+      fq: `groups:${group.id}`,
       offset: 0,
       limit: 10,
       type: "dataset",
@@ -61,7 +61,7 @@ export default function GroupPage({ group, initialDatasets }): JSX.Element {
     {
       id: "datasets",
       content:  (
-        <DatasetList type="group" name={group._name} initialDatasets={initialDatasets} />
+        <DatasetList type="group" name={group?.groups[0]?.name+'--'+group.name} initialDatasets={initialDatasets} />
       ),
       title: "Datasets",
     },

--- a/pages/groups/index.tsx
+++ b/pages/groups/index.tsx
@@ -10,7 +10,7 @@ import { getAllGroups } from "@/lib/queries/groups";
 import { GroupPageStructuredData } from "@/components/schema/GroupPageStructuredData";
 
 export async function getServerSideProps() {
-  const groups = await getAllGroups({ detailed: true });
+  const groups = await getAllGroups();
   return {
     props: {
       groups,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved dataset and group filtering so listings use more precise owner and group identifiers for consistent results across org and group pages.
  * Adjusted group list retrieval to a leaner/detail-default mode, reducing extra metadata in group listings.

* **Chores**
  * Updated components to pass the new identifiers to dataset lists to ensure correct dataset scoping.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->